### PR TITLE
Add `start_delay_template` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Simple integration designed to allow TTS playback through a [snapcast](https://m
 
 ## Installation
 
-Install via HACS or copy `./custom_components/snapcast_player/` to `/config/custom_components/braviatv_psk/`
+Install via HACS or copy `./custom_components/snapcast_player/` to `/config/custom_components/`
 
 ## Configuration Variables
 
@@ -13,6 +13,7 @@ Install via HACS or copy `./custom_components/snapcast_player/` to `/config/cust
 |host     | yes      | `127.0.0.1`       | Hostname or IP address of the snapcast server |
 | port    | no       | `4953`            | Port to stream audio to, default is `4953` |
 | start_delay | no   | `1s`              | Insert a delay at the stream start. Useful to prevent TTS from being slightly cut-off |
+| start_delay_template | no |            | Add a dynamic delay, for example to allow time for a speaker to turn on |
 
 ## Example Config
 

--- a/custom_components/snapcast_player/media_player.py
+++ b/custom_components/snapcast_player/media_player.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 import asyncio
 import logging
+from pipes import Template
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.template import Template
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
     PLATFORM_SCHEMA,
@@ -28,6 +31,7 @@ CONF_HOST = "host"
 CONF_PORT = "port"
 CONF_NAME = "name"
 CONF_START_DELAY = "start_delay"
+CONF_START_DELAY_TEMPLATE = "start_delay_template"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -35,6 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_START_DELAY): cv.string,
         vol.Optional(CONF_PORT): cv.string,
         vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_START_DELAY_TEMPLATE): cv.template,
     }
 )
 
@@ -48,8 +53,17 @@ def setup_platform(
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT, DEFAULT_PORT)
     start_delay = config.get(CONF_START_DELAY)
+    start_delay_template = config.get(CONF_START_DELAY_TEMPLATE)
+    if start_delay_template is not None:
+        start_delay_template.hass = hass
 
-    add_entities([SnapcastPlayer(host, name, port, start_delay)])
+    player_entity = SnapcastPlayer(host, name, port, start_delay, start_delay_template)
+
+    def _shutdown(call):
+        player_entity.media_stop()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown)
+    add_entities([player_entity])
 
 
 class SnapcastPlayer(MediaPlayerEntity):
@@ -61,12 +75,20 @@ class SnapcastPlayer(MediaPlayerEntity):
         | MediaPlayerEntityFeature.STOP
     )
 
-    def __init__(self, host: str, name: str | None, port: str | None, start_delay: str | None) -> None:
+    def __init__(
+        self,
+        host: str,
+        name: str | None,
+        port: str | None,
+        start_delay: str | None,
+        start_delay_template: Template | None,
+    ) -> None:
         self._host = host
         self._port = port
         self._attr_state = MediaPlayerState.IDLE
         self._name = name
         self._start_delay = start_delay
+        self._start_delay_template = start_delay_template
         self._uri = None
         self._proc = None
 
@@ -80,8 +102,14 @@ class SnapcastPlayer(MediaPlayerEntity):
         media_id = async_process_play_media_url(self.hass, media_id)
         self._uri = media_id
         format_args = ["-f", "u16le", "-acodec", "pcm_s16le", "-ac", "2", "-ar", "48000"]
-        delay_args = [] if self._start_delay is None else ["-af", f"adelay={self._start_delay}:all=true"]
+        delay = self._start_delay
+        if self._start_delay_template is not None:
+            delay = self._start_delay_template.async_render()
+        delay_args = [] if delay is None else ["-af", f"adelay={delay}:all=true"]
         out_arg = f"tcp://{self._host}:{self._port}"
+        # Already playing, terminate existing process
+        if self._proc is not None and self._proc.returncode is None:
+            self._proc.terminate()
         self._proc = await asyncio.create_subprocess_exec(
             *["ffmpeg", "-y", "-i", media_id, *format_args, *delay_args, out_arg],
             stderr=asyncio.subprocess.PIPE,


### PR DESCRIPTION
- Handle homeassistant shutdown
- Calling `play_media` will now terminate any existing stream